### PR TITLE
Use Cassandra 2.0 series (instead of pinning explicit version)

### DIFF
--- a/lib/orizuru/operations.py
+++ b/lib/orizuru/operations.py
@@ -113,7 +113,7 @@ deb [arch=amd64] http://apt.newrelic.com/debian/ newrelic non-free
     def datastax(self):
         if env.host_string in self._metadata.containers:
             cuisine.file_write("/etc/apt/sources.list.d/datastax.list", """
-deb [arch=amd64] http://debian.datastax.com/community stable main
+deb [arch=amd64] http://debian.datastax.com/community 2.0 main
 """)
             self.repokey("http://debian.datastax.com/debian/repo_key")
 

--- a/stages/stage7/fabfile.py
+++ b/stages/stage7/fabfile.py
@@ -205,8 +205,7 @@ def stage7_container_cassandra():
     for container in sorted(metadata.roles["container_cassandra"]):
         cshosts.append("%s" % metadata.containers[container]["ip"])
 
-    cuisine.package_ensure("cassandra=2.0.10")
-    cuisine.package_ensure("dsc20=2.0.10-1")
+    cuisine.package_ensure("dsc20")
 
     ip_address = metadata.containers[env.host_string]["ip"]
 


### PR DESCRIPTION
Instead of explicitly installing and holding Cassandra 2.0.10,
use the 2.0 series and allow receiving updates for these.

Fixes: https://github.com/midonet/orizuru/issues/6
Signed-off-by: Jan Hilberath jan@midokura.com
