### PR TITLE
Skip pinging midonet_manager when using OSS repo

### DIFF
--- a/stages/stage5/fabfile.py
+++ b/stages/stage5/fabfile.py
@@ -79,6 +79,12 @@ def stage5_ping_containers():
     metadata = Config(os.environ["CONFIGFILE"])
 
     for container in sorted(metadata.containers):
+        role = metadata.containers[container]["role"]
+        repo = metadata.config["midonet_repo"]
+
+        if (role == 'midonet_manager' and repo != "MEM"):
+            continue
+
         container_ip = metadata.containers[container]["ip"]
 
         run("""


### PR DESCRIPTION
This commit will stop fabric from pinging midonet_manager container,
which doesn't exist when using OSS repo.
